### PR TITLE
Auto-send osdk SDK version query param to edge.

### DIFF
--- a/DemoApp/DemoAppKotlin/app/build.gradle
+++ b/DemoApp/DemoAppKotlin/app/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("de.nanogiants.android-versioning") version "2.4.0"
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -10,8 +14,11 @@ android {
         applicationId "co.optable.androidsdkdemo"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+
+        versionCode versioning.getVersionCode()
+        versionName versioning.getVersionName(false)
+        archivesBaseName = "optable-android-sdk-demo-kotlin"
+
         multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -23,10 +30,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }
@@ -53,5 +62,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     implementation 'com.google.android.gms:play-services-ads:19.3.0'
-    implementation 'com.github.Optable:optable-android-sdk:master-SNAPSHOT'
+    implementation "com.github.Optable:optable-android-sdk:" + versioning.getVersionName(false)
 }

--- a/DemoApp/DemoAppKotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/DemoApp/DemoAppKotlin/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/android_sdk/build.gradle
+++ b/android_sdk/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("de.nanogiants.android-versioning") version "2.4.0"
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -9,8 +13,10 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+
+        versionCode versioning.getVersionCode()
+        versionName versioning.getVersionName(false)
+        archivesBaseName = "optable-android-sdk"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/android_sdk/src/main/java/co/optable/android_sdk/core/Client.kt
+++ b/android_sdk/src/main/java/co/optable/android_sdk/core/Client.kt
@@ -28,7 +28,17 @@ class Client(private val config: Config, private val context: Context) {
 
     private class RequestInterceptor(private val userAgent: String, private val storage: LocalStorage): Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
-            var newRequest = chain.request().newBuilder().addHeader("User-Agent", userAgent)
+            var oldRequest = chain.request()
+            var newURL = oldRequest.url.newBuilder()
+                .addQueryParameter("osdk",
+                    "android-" +
+                            BuildConfig.VERSION_NAME + "-" +
+                            BuildConfig.VERSION_CODE.toString()
+                ).build()
+            var newRequest = oldRequest.newBuilder()
+                .url(newURL)
+                .addHeader("User-Agent", userAgent)
+
             val pass = storage.getPassport()
             if (pass != null) {
                 newRequest = newRequest.addHeader("X-Optable-Visitor", pass)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Related to https://github.com/Optable/optable-sandbox/issues/223

- Bump gradle distro to v6.5 for both SDK and kotlin demo app
- Include de.nanogiants.android-versioning gradle plugin and use it for
  both SDK and kotlin demo app, to control the build config version code
  and name
- Kotlin demo app to track latest release tag of SDK via jitpack, thanks
  to aforementioned android-versioning plugin
- Automatically send android SDK version via `osdk` query param in all
  requests to edge from SDK