### PR TITLE
Fix unit tests

### DIFF
--- a/DemoApp/DemoAppKotlin/app/build.gradle
+++ b/DemoApp/DemoAppKotlin/app/build.gradle
@@ -9,7 +9,6 @@ android {
     namespace "co.optable.androidsdkdemo"
 
     defaultConfig {
-        // TODO: Change
         applicationId "co.optable.androidsdkdemo"
         minSdkVersion 21
         targetSdkVersion 34

--- a/android_sdk/build.gradle
+++ b/android_sdk/build.gradle
@@ -4,15 +4,6 @@ plugins {
     id("de.nanogiants.android-versioning") version "2.4.0"
 }
 
-// TODO: Check
-//apply plugin: 'de.mobilej.unmock'
-
-//unMock {
-//    keep "android.net.Uri"
-//    keepStartingWith "libcore."
-//    keepAndRename "java.nio.charset.Charsets" to "xjava.nio.charset.Charsets"
-//}
-
 android {
     compileSdk 34
 
@@ -69,7 +60,11 @@ dependencies {
 
     implementation 'com.google.android.gms:play-services-ads:24.6.0'
 
-    testImplementation 'junit:junit:4.13.2'
+    // Unit tests
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.16")
+
+    // UI tests
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/android_sdk/src/test/java/co/optable/android_sdk/OptableSDKUnitTest.kt
+++ b/android_sdk/src/test/java/co/optable/android_sdk/OptableSDKUnitTest.kt
@@ -8,13 +8,15 @@ import android.net.Uri
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 /**
  * OptableSDK unit tests
  */
+@RunWith(RobolectricTestRunner::class)
 class OptableSDKUnitTest {
 
-    // TODO: Fix
     @Test
     fun eid_isCorrect() {
         val expected = "e:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"


### PR DESCRIPTION
Completely remove the 3rd-party lib Unmock. Use Robolectric supported by Google. 
Closes #22. 