### PR TITLE
Configurable TTL for the targeting cache (default 24 hours)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ developers running the DCN locally for testing.
 - `skipAdvertisingIdDetection` Boolean flag to skip the detection of advertising IDs. Default is false.
 - `consents` Optional `OptableConsents` object for providing custom consent information. If not provided, default values will be used.
 - `origin` An optional value for the HTTP `Origin` header sent with Optable API requests. Unrelated to `originSlug`.
+- `cacheTtl` The time to live, in seconds, of the targeting data cached by the `targeting` API. Default
+value is 24 hours. See [Caching Targeting Data](#caching-targeting-data).
 
 ```kotlin
 val config = OptableConfig(
@@ -118,6 +120,7 @@ val config = OptableConfig(
     skipAdvertisingIdDetection = false,
     consents = OptableConsents(),
     origin = "https://www.acmeco.com",
+    cacheTtl = 24 * 60 * 60L,
 )
 ```
 
@@ -461,6 +464,25 @@ optable.targetingClearCache()
 ```
 
 Note that both `targetingFromCache()` and `targetingClearCache()` are synchronous.
+
+##### Cache expiry
+
+The cached targeting data has a time to live of 24 hours by default. Once the cached data is older than the TTL,
+`targetingFromCache()` treats it as absent: it returns `null` and clears the expired data from storage. Call
+`targeting()` again to refresh it.
+
+You can change the TTL with the `cacheTtl` parameter of `OptableConfig`, which is expressed in
+seconds. For example, to expire the cached targeting data after one hour:
+
+```kotlin
+val config = OptableConfig(
+  ...
+  cacheTtl = 60 * 60L,
+)
+```
+
+Setting `cacheTtl` to zero or less effectively disables the cache, since the data is then considered
+expired as soon as it is stored.
 
 ### Witness API
 

--- a/android_sdk/src/main/java/co/optable/sdk/OptableConfig.kt
+++ b/android_sdk/src/main/java/co/optable/sdk/OptableConfig.kt
@@ -17,6 +17,8 @@ import android.content.Context
  * @param consents Optional `OptableConsents` object for providing custom consent information. If not provided, default values will be used.
  * @param origin An optional value for the HTTP `Origin` header sent with Optable API requests. Unrelated to `originSlug`.
  *   Settable after construction, which is how Java callers set it without passing every preceding parameter.
+ * @param cacheTtl The targeting cache time to live in seconds. Default value is 24 hours.
+ * A value of zero or less disables the cache.
  */
 class OptableConfig @JvmOverloads constructor(
     providedContext: Context,
@@ -30,7 +32,12 @@ class OptableConfig @JvmOverloads constructor(
     internal val skipAdvertisingIdDetection: Boolean = false,
     var consents: OptableConsents = OptableConsents(),
     var origin: String? = null,
+    internal val cacheTtl: Long = DEFAULT_TARGETING_CACHE_TTL_SECONDS,
 ) {
+
+    companion object {
+        const val DEFAULT_TARGETING_CACHE_TTL_SECONDS: Long = 24 * 60 * 60L
+    }
 
     internal val context = providedContext.applicationContext
 

--- a/android_sdk/src/main/java/co/optable/sdk/OptableSDK.kt
+++ b/android_sdk/src/main/java/co/optable/sdk/OptableSDK.kt
@@ -189,6 +189,9 @@ class OptableSDK(
 
     /**
      * Returns the targeting data from the cache, if available.
+     *
+     * Cached data older than `OptableConfig.cacheTtl` seconds (24 hours by default) is considered
+     * absent: null is returned and the expired data is cleared from the cache.
      */
     fun targetingFromCache(): OptableTargeting? {
         return storage.getTargeting()

--- a/android_sdk/src/main/java/co/optable/sdk/core/LocalStorage.kt
+++ b/android_sdk/src/main/java/co/optable/sdk/core/LocalStorage.kt
@@ -28,6 +28,8 @@ internal class LocalStorage(
     private val prefs = PreferenceManager.getDefaultSharedPreferences(config.context)
     private val passportKey = generateUniqueKey("PASS", config)
     private val targetingKey = generateUniqueKey("TGT", config)
+    private val targetingTimestampKey = generateUniqueKey("TGT_TS", config)
+    private val targetingCacheTtlMs = config.cacheTtl.coerceAtMost(Long.MAX_VALUE / 1000) * 1000L
     private val id5SignatureKey = generateUniqueKey("ID5SIG", config)
 
     fun getPassport(): String? {
@@ -43,10 +45,15 @@ internal class LocalStorage(
     fun getTargeting(): OptableTargeting? {
         try {
             val targeting = prefs.getString(targetingKey, null) ?: return null
+            if (isTargetingExpired()) {
+                Log.i("OptableSDK", "Cached targeting is expired. Clearing...")
+                clearTargeting()
+                return null
+            }
             return Gson().fromJson(targeting, OptableTargeting::class.java)
         } catch (e: Exception) {
             Log.e("OptableSDK", "Can't parse cached targeting: ${e.message}. Clearing...")
-            prefs.edit(commit = true) { remove(targetingKey) }
+            runCatching { clearTargeting() }
         }
         return null
     }
@@ -55,6 +62,7 @@ internal class LocalStorage(
         try {
             prefs.edit(commit = true) {
                 putString(targetingKey, Gson().toJson(targeting))
+                putLong(targetingTimestampKey, System.currentTimeMillis())
             }
         } catch (e: Exception) {
             Log.e("OptableSDK", "Can't set targeting: ${e.message}")
@@ -64,6 +72,7 @@ internal class LocalStorage(
     fun clearTargeting() {
         prefs.edit(commit = true) {
             remove(targetingKey)
+            remove(targetingTimestampKey)
             remove(id5SignatureKey)
         }
     }
@@ -76,6 +85,16 @@ internal class LocalStorage(
         prefs.edit(commit = true) {
             putString(id5SignatureKey, signature)
         }
+    }
+
+    private fun isTargetingExpired(): Boolean {
+        val cachedAt = prefs.getLong(targetingTimestampKey, 0L)
+        if (cachedAt <= 0L) {
+            return true
+        }
+        val age = System.currentTimeMillis() - cachedAt
+        // A negative age means the device clock moved backwards, so the age is unreliable.
+        return age !in 0..<targetingCacheTtlMs
     }
 
     fun getSubjectToGdpr(): Int? {

--- a/android_sdk/src/test/java/co/optable/sdk/OptableConfigTest.kt
+++ b/android_sdk/src/test/java/co/optable/sdk/OptableConfigTest.kt
@@ -41,6 +41,8 @@ class OptableConfigTest {
         assertFalse(config.skipAdvertisingIdDetection)
         assertNull(config.origin)
         assertEquals(mockApplicationContext, config.context)
+        assertEquals(24 * 60 * 60L, config.cacheTtl)
+        assertEquals(OptableConfig.DEFAULT_TARGETING_CACHE_TTL_SECONDS, config.cacheTtl)
     }
 
     @Test
@@ -57,6 +59,7 @@ class OptableConfigTest {
             customUserAgent = "TestAgent/1.0",
             skipAdvertisingIdDetection = true,
             consents = customConsents,
+            cacheTtl = 60L,
             origin = "https://www.optable.co"
         )
 
@@ -70,6 +73,7 @@ class OptableConfigTest {
         assertTrue(config.skipAdvertisingIdDetection)
         assertEquals(customConsents, config.consents)
         assertEquals("https://www.optable.co", config.origin)
+        assertEquals(60L, config.cacheTtl)
     }
 
     @Test

--- a/android_sdk/src/test/java/co/optable/sdk/core/LocalStorageTest.kt
+++ b/android_sdk/src/test/java/co/optable/sdk/core/LocalStorageTest.kt
@@ -13,6 +13,7 @@ import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.lang.reflect.Field
@@ -23,10 +24,12 @@ class LocalStorageTest {
         private const val KEY_SUBJECT_TO_GDPR = "IABTCF_gdprApplies"
         private const val KEY_GDPR_CONSENT = "IABTCF_TCString"
         private const val KEY_GPP_CONSENT = "IABGPP_2_TCString"
+        private const val HOUR_MS = 60 * 60 * 1000L
     }
 
     private lateinit var mockSharedPreferences: SharedPreferences
     private lateinit var mockEditor: SharedPreferences.Editor
+    private lateinit var mockContext: Context
     private lateinit var localStorage: LocalStorage
     private lateinit var targeting: OptableTargeting
 
@@ -34,10 +37,11 @@ class LocalStorageTest {
     fun setUp() {
         mockSharedPreferences = mockk(relaxed = true)
         mockEditor = mockk(relaxed = true)
-        val mockContext = mockk<Context>(relaxed = true)
+        mockContext = mockk(relaxed = true)
 
         mockkStatic(PreferenceManager::class, Base64::class, Log::class)
         every { Log.e(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
 
         every { PreferenceManager.getDefaultSharedPreferences(any()) } returns mockSharedPreferences
 
@@ -84,7 +88,20 @@ class LocalStorageTest {
     fun `getTargeting should return null when not set`() {
         val targetingKey = getPrivateKey(localStorage, "targetingKey")
         every { mockSharedPreferences.getString(targetingKey, null) } returns null
+        cacheTimestamp(localStorage, System.currentTimeMillis() - HOUR_MS)
         assertNull(localStorage.getTargeting())
+    }
+
+    @Test
+    fun `getTargeting should not write to the cache when no targeting is stored`() {
+        val targetingKey = getPrivateKey(localStorage, "targetingKey")
+        every { mockSharedPreferences.getString(targetingKey, null) } returns null
+        // No timestamp either, as on a fresh install or right after clearTargeting().
+        cacheTimestamp(localStorage, 0L)
+
+        assertNull(localStorage.getTargeting())
+
+        verify(exactly = 0) { mockSharedPreferences.edit() }
     }
 
     @Test
@@ -92,6 +109,7 @@ class LocalStorageTest {
         val targetingKey = getPrivateKey(localStorage, "targetingKey")
         val targetingJson = Gson().toJson(targeting)
         every { mockSharedPreferences.getString(targetingKey, null) } returns targetingJson
+        cacheTimestamp(localStorage, System.currentTimeMillis() - HOUR_MS)
 
         localStorage.setTargeting(targeting)
 
@@ -101,10 +119,83 @@ class LocalStorageTest {
     }
 
     @Test
+    fun `setTargeting should store the time at which the data was cached`() {
+        val timestampKey = getPrivateKey(localStorage, "targetingTimestampKey")
+        val before = System.currentTimeMillis()
+
+        localStorage.setTargeting(targeting)
+
+        val cachedAt = slot<Long>()
+        verify { mockEditor.putLong(timestampKey, capture(cachedAt)) }
+        assertTrue(cachedAt.captured >= before)
+        assertTrue(cachedAt.captured <= System.currentTimeMillis())
+    }
+
+    @Test
     fun `clearTargeting should remove targeting data`() {
         val targetingKey = getPrivateKey(localStorage, "targetingKey")
+        val timestampKey = getPrivateKey(localStorage, "targetingTimestampKey")
         localStorage.clearTargeting()
         verify { mockEditor.remove(targetingKey) }
+        verify { mockEditor.remove(timestampKey) }
+    }
+
+    @Test
+    fun `getTargeting should return null and clear the cache when the data is older than the TTL`() {
+        val targetingKey = getPrivateKey(localStorage, "targetingKey")
+        val timestampKey = getPrivateKey(localStorage, "targetingTimestampKey")
+        every { mockSharedPreferences.getString(targetingKey, null) } returns Gson().toJson(targeting)
+        // The default TTL is 24 hours.
+        cacheTimestamp(localStorage, System.currentTimeMillis() - 25 * HOUR_MS)
+
+        assertNull(localStorage.getTargeting())
+
+        verify { mockEditor.remove(targetingKey) }
+        verify { mockEditor.remove(timestampKey) }
+    }
+
+    @Test
+    fun `getTargeting should return null when the cached data has no timestamp`() {
+        val targetingKey = getPrivateKey(localStorage, "targetingKey")
+        every { mockSharedPreferences.getString(targetingKey, null) } returns Gson().toJson(targeting)
+        cacheTimestamp(localStorage, 0L)
+
+        assertNull(localStorage.getTargeting())
+
+        verify { mockEditor.remove(targetingKey) }
+    }
+
+    @Test
+    fun `getTargeting should apply the TTL configured in OptableConfig`() {
+        val ttlSeconds = 2 * 60 * 60L
+        val storage = LocalStorage(
+            OptableConfig(mockContext, "testhost", "testtenant", "testslug", cacheTtl = ttlSeconds)
+        )
+        val targetingKey = getPrivateKey(storage, "targetingKey")
+        every { mockSharedPreferences.getString(targetingKey, null) } returns Gson().toJson(targeting)
+
+        cacheTimestamp(storage, System.currentTimeMillis() - HOUR_MS)
+        assertEquals(targeting.gamTargetingKeywords, storage.getTargeting()?.gamTargetingKeywords)
+
+        cacheTimestamp(storage, System.currentTimeMillis() - 3 * HOUR_MS)
+        assertNull(storage.getTargeting())
+    }
+
+    @Test
+    fun `getTargeting should keep the cache valid when the configured TTL is huge`() {
+        val storage = LocalStorage(
+            OptableConfig(mockContext, "testhost", "testtenant", "testslug", cacheTtl = Long.MAX_VALUE)
+        )
+        val targetingKey = getPrivateKey(storage, "targetingKey")
+        every { mockSharedPreferences.getString(targetingKey, null) } returns Gson().toJson(targeting)
+        cacheTimestamp(storage, System.currentTimeMillis() - HOUR_MS)
+
+        assertEquals(targeting.gamTargetingKeywords, storage.getTargeting()?.gamTargetingKeywords)
+    }
+
+    private fun cacheTimestamp(storage: LocalStorage, timestamp: Long) {
+        val timestampKey = getPrivateKey(storage, "targetingTimestampKey")
+        every { mockSharedPreferences.getLong(timestampKey, 0L) } returns timestamp
     }
 
     @Test
@@ -137,6 +228,7 @@ class LocalStorageTest {
     fun `getTargeting should handle invalid JSON gracefully`() {
         val targetingKey = getPrivateKey(localStorage, "targetingKey")
         every { mockSharedPreferences.getString(targetingKey, null) } returns "{invalid-json}"
+        cacheTimestamp(localStorage, System.currentTimeMillis() - HOUR_MS)
 
         val result = localStorage.getTargeting()
 

--- a/android_sdk/src/test/java/co/optable/sdk/core/LocalStorageTest.kt
+++ b/android_sdk/src/test/java/co/optable/sdk/core/LocalStorageTest.kt
@@ -155,6 +155,20 @@ class LocalStorageTest {
     }
 
     @Test
+    fun `getTargeting should return null and clear the cache when the timestamp is in the future`() {
+        val targetingKey = getPrivateKey(localStorage, "targetingKey")
+        val timestampKey = getPrivateKey(localStorage, "targetingTimestampKey")
+        every { mockSharedPreferences.getString(targetingKey, null) } returns Gson().toJson(targeting)
+        // A device clock that moved backwards leaves the entry stamped in the future, making its age unusable.
+        cacheTimestamp(localStorage, System.currentTimeMillis() + HOUR_MS)
+
+        assertNull(localStorage.getTargeting())
+
+        verify { mockEditor.remove(targetingKey) }
+        verify { mockEditor.remove(timestampKey) }
+    }
+
+    @Test
     fun `getTargeting should return null when the cached data has no timestamp`() {
         val targetingKey = getPrivateKey(localStorage, "targetingKey")
         every { mockSharedPreferences.getString(targetingKey, null) } returns Gson().toJson(targeting)


### PR DESCRIPTION
Closes https://github.com/Optable/optable-android-sdk/issues/42

OptableConfig.kt:
- Add cacheTtl parameter and DEFAULT_TARGETING_CACHE_TTL_SECONDS 24h constant.
LocalStorage.kt:
- Added targetingTimestampKey and targetingCacheTtlMs
- Save cache timestamp on every setTargeting
- Check if cache expired before returning getTargeting() result
- Clear cache timestamp alongside cache in clearTargeting()
OptableSDK.kt:
- Extended targetingFromCache() KDoc to reflect TTL changes
Docs:
- Updated README.md with updated cache mechanics
Tests:
- Added tests for cache expiration
- Updated OptableConfigTest.kt